### PR TITLE
fix: updated link to tec discord

### DIFF
--- a/docs/getting-started-ourcommunity.md
+++ b/docs/getting-started-ourcommunity.md
@@ -12,5 +12,5 @@ We host weekly calls that are open to anyone. Just check out our [community cale
 ## Our community channels:
 * [Token Engineering Discord](https://discord.gg/mFcqFwGhpy) - 💬 Discord server with numerous channels for various topics related to token engineering.
 * [Token Engineering Twitter](https://twitter.com/tokengineering) - 💬 Daily updates from the token universe
-* [TE Commons Discord](https://discord.gg/8u7Z3ft) - 💬 Token Engineering Commons - managing and funding Token Engineering public goods
+* [TE Commons Discord](https://discord.gg/st9dWnEQMU) - 💬 Token Engineering Commons - managing and funding Token Engineering public goods
 * [cadCAD Community Forum](https://community.cadcad.org/) - 🖥️ A community of researchers learning & building on the open source simulation & modeling tool that is the foundation of open token engineering.


### PR DESCRIPTION
## Description:
This PR updates the Discord Link for the TEC discord server.
(the current link is an invite for TE discord rather than TE Commons Discord)

scope: [getting-started-ourcommunity.md](https://github.com/TokenEngineeringCommunity/website/blob/master/docs/getting-started-ourcommunity.md)

```diff
- * [TE Commons Discord](https://discord.gg/8u7Z3ft) - 💬 Token Engineering Commons - managing and funding Token Engineering public goods
+ * [TE Commons Discord](https://discord.gg/st9dWnEQMU) - 💬 Token Engineering Commons - managing and funding Token Engineering public goods
```